### PR TITLE
Wrap non-printable characters in \[\]

### DIFF
--- a/minimal-terminal-prompt-grayscale.sh
+++ b/minimal-terminal-prompt-grayscale.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## Text Styles
+RESET='\[\e[0m\]' # What color will comand outputs be in
+BOLD='\[\e[1m\]' # BOLD
+
+## Config
+SHOW_GIT=true
+
+## If this is a valid git repo, echo the current branch name
+parse_git_branch() {
+     git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+}
+
+## Build-up what will be the final PS1 string
+set_bash_prompt(){
+  PS1="${RESET}\n"
+  PS1+="@\u ➜ ${BOLD}\w ${RESET}"
+
+  if [ "$SHOW_GIT" = true ] ; then
+    PS1+="$(parse_git_branch)"
+  fi
+
+  PS1+="\n└─▶"
+  PS1+="${RESET} \$ "
+}
+
+## Done, now just set the PS1 prompt :)
+PROMPT_COMMAND=set_bash_prompt

--- a/minimal-terminal-prompt.sh
+++ b/minimal-terminal-prompt.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 ## Define all the colors
-COL_USER_HOST='\e[35m' # The color of 'user@host.ext'
-COL_CURSOR='\e[35m' # The color of the trailing cursor arrow
-COL_CURRENT_PATH='\e[37m' # The color of the current directory full path
-COL_GIT_STATUS_CLEAN='\e[93m' # Color of fresh git branch name, with NO changes
-COL_GIT_STATUS_CHANGES='\e[92m' # Color of git branch, affter its diverged from remote
+COL_USER_HOST='\[\e[35m\]' # The color of 'user@host.ext'
+COL_CURSOR='\[\e[35m\]' # The color of the trailing cursor arrow
+COL_CURRENT_PATH='\[\e[37m\]' # The color of the current directory full path
+COL_GIT_STATUS_CLEAN='\[\e[93m\]' # Color of fresh git branch name, with NO changes
+COL_GIT_STATUS_CHANGES='\[\e[92m\]' # Color of git branch, affter its diverged from remote
 
 ## Text Styles
-RESET='\e[0m' # What color will comand outputs be in
-BOLD='\e[1m' # BOLD
+RESET='\[\e[0m\]' # What color will comand outputs be in
+BOLD='\[\e[1m\]' # BOLD
 
 ## Config
 SHOW_GIT=true


### PR DESCRIPTION
Fixes issue with word wrapping in bash

References:
[why-does-this-bash-prompt-sometimes-keep-part-of-previous-commands](https://superuser.com/questions/382456/why-does-this-bash-prompt-sometimes-keep-part-of-previous-commands-when-scrollin)
[syntax-prompt](https://ss64.com/bash/syntax-prompt.html)
